### PR TITLE
Change framework target to v4.5 instead of v4.5.2

### DIFF
--- a/InfluxClient/InfluxClient.csproj
+++ b/InfluxClient/InfluxClient.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>InfluxClient</RootNamespace>
     <AssemblyName>InfluxClient</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
I am attempting to use InfluxClient in a Seq app which currently is restricted to .NET v4.5. 

I can't see anything that requires v4.5.2.